### PR TITLE
Refactor `FitsInto` to return whole multiple amounts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,6 @@ install:
 
 script:
   - go test -v -cover
+
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -10,25 +10,25 @@ Nice currency calculations.
 // Currency looks like
 type Currency struct { cents uint }
 
-// You can make a new Currency by declaring the number of cents directly
-c1 := Currency{1234} // $123.40
-
-// You can also parse strings and floats
+// You can make new Currencies from strings and floats with normal rounding
 c2, _ := NewFromString("500") // $500.00
 c3, _ := NewFromFloat(2.4855) // $2.49
 
 // Conversions that don't work return an error
 _, err := NewFromString("abcd") // err != nil
+_, err := NewFromFloat(-50)     // err != nil
 
 // Basic operations are available
-payment := NewFromString("10")
-balance := NewFromString("100")
-balance.Add(payment)          // balance: $110.00
-balance.Sub(Currency{2500})   // balance:  $85.00
-balance.Mul(0.1)              // balance:   $8.50
+payment, _ := NewFromString("10.0")
+bill, _ := NewFromFloat(25)
+balance, _ := NewFromString("100")
+balance.Add(payment) // balance: $110.00
+balance.Sub(bill)    // balance:  $85.00
+balance.Mul(0.1)     // balance:   $8.50
 
-// There are convenience mod and remainder functions
+// It's easy to determine the number of times one currency fits into another
 stockPrice := NewFromFloat(3.33)
-account := NewFromFloat(10.00)
-times, remainder := stockPrice.FitsInto(account) // times: 3, remainder: $0.01
+balance := NewFromFloat(10.00)
+times, maxStockPurchase := stockPrice.FitsInto(balance) // times: 3, maxStockPurchase: $9.99
+balance.Sub(maxStockPurchase) // balance: $0.01
 ```

--- a/currency.go
+++ b/currency.go
@@ -54,20 +54,18 @@ func (c Currency) ToFloat() float64 {
 	return float64(c.cents) / 100
 }
 
-// FitsInto : Finds whole number of divisions of two currencies, with remainder. If either argument is zero then (0, $0.00) is returned
+// FitsInto : Finds whole number of divisions of two currencies, with maximum whole
+// multiple. If either argument is zero then (0, $0.00) is returned
 func (c *Currency) FitsInto(total Currency) (uint, Currency) {
-	if c.cents == 0 {
-		// Guard against div by zero in times
+	// Return default values if c is empty or total is smaller than divisor
+	if c.cents == 0 || c.cents > total.cents {
 		return 0, Currency{}
-	} else if total.cents == 0 {
-		// X % 0 = 0 but we want X % 0 = X
-		return 0, Currency{c.cents}
 	}
 
 	times := total.cents / c.cents
-	remainder := total.cents % c.cents
+	wholeMultiple := total.cents - (total.cents % c.cents)
 
-	return times, Currency{remainder}
+	return times, Currency{wholeMultiple}
 }
 
 // Add : Increase the value of a Currency

--- a/currency_test.go
+++ b/currency_test.go
@@ -85,20 +85,20 @@ var (
 
 func TestFitsInto(t *testing.T) {
 	tests := map[testPair]expectedPair{
-		// $30 fits into $100: 3 times with $10 remainder
-		testPair{thirtyD, hundredD}: expectedPair{3, tenD},
+		// $2.75 fits into $10: 3 times at $8.25
+		testPair{Currency{275}, tenD}: expectedPair{3, Currency{825}},
 
-		// $100 fits into $30: 0 times with $30 remainder
-		testPair{hundredD, thirtyD}: expectedPair{0, thirtyD},
+		// $100 fits into $30: 0 times at $0
+		testPair{hundredD, thirtyD}: expectedPair{0, zeroD},
 
-		// $0 fits into $10: 0 times with $0 remainder
+		// $0 fits into $10: 0 times at $0
 		testPair{zeroD, tenD}: expectedPair{0, zeroD},
 
-		// $10 fits into $0: 0 times with $10 remainder
-		testPair{tenD, zeroD}: expectedPair{0, tenD},
+		// $10 fits into $0: 0 times at $0
+		testPair{tenD, zeroD}: expectedPair{0, zeroD},
 
-		// $3.33 fits into $10: 3 times with $0.01 remainder
-		testPair{Currency{333}, tenD}: expectedPair{3, Currency{1}},
+		// $10 fits into $10: 1 time at $10
+		testPair{tenD, tenD}: expectedPair{1, tenD},
 	}
 
 	for tp, ep := range tests {


### PR DESCRIPTION
🚨 **This will introduce breaking changes** 🚨 
To logic, but programs will still compile.

I hate hate hate hate writing code like this:
```go
quantityToSell, _ := q.Price.FitsInto(s.amount)
if quantityToSell < 1 {
	abortTx("Cannot sell less than one stock")
}

profit := q.Price
profit.Mul(float64(quantityToSell))
acct.balance.Add(profit)
```
and would rather write
```go
quantityToSell, profit := q.Price.FitsInto(s.amount)
if quantityToSell < 1 {
	abortTx("Cannot sell less than one stock")
}

acct.balance.Add(profit)
```
IMO this is _significantly_ easier to work with.

### Extent of breaking changes
- Milestone1 will compile but its logic will be wrong
- [This PR](https://github.com/DistributedDesigns/worker/pull/21) will need another commit that follows the new structure